### PR TITLE
fixed issues with propTypes in dialog.jsx

### DIFF
--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -49,11 +49,9 @@ const Main = styled.div`
   background-color: rgba(0, 0, 0, 0.6);
   z-index: 3;
 `;
-const propTypes = {};
 
 class Dialog extends React.Component{
-
-render() {
+  render() {
     const {
       header,
       message,
@@ -79,16 +77,5 @@ render() {
     );
   }
 }
-
-}
-
-
-Dialog = props => {
-  const {
-    header, message, isOpen, stateManager,completionTimeMessage
-  } = props;
-
-
-Dialog.propTypes = propTypes;
 
 export default Dialog;


### PR DESCRIPTION
This is a proposed solution to an app-breaking issue #28. The proposed solution removes propTypes. 