### PR TITLE
Fix reset game cancel button

### DIFF
--- a/src/game/sudoku.js
+++ b/src/game/sudoku.js
@@ -273,7 +273,7 @@ class Sudoku extends React.Component {
       <Fragment>
         <Background />
         {showReset && (
-          <Reset onAction={this.resetBoard} onCancel={this.toggleReset} />
+          <Reset onAction={this.resetBoard} onClose={this.toggleReset} />
         )}
         <Main>
           <ThemeSelector onChange={changeTheme} />


### PR DESCRIPTION
Cancel button in the reset game dialog was not functioning because of an incorrect prop name.