### PR TITLE
Add missing 'title' Button prop

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { MdClear } from 'react-icons/md';
 import StyledButton from './button.styled';
 
-const Button = ({ onClick, value, enabled, children, className }) => (
+const Button = ({ onClick, value, enabled, children, className, title }) => (
   <StyledButton
     title={title}
     className={className}


### PR DESCRIPTION
You missed adding `title` to the props destruction on line 7 in button.js when merging #75. As it is now, the game wont load.